### PR TITLE
Bugfix/candidate order in rank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 .project
 .classpath
 .settings
+
+.idea
+*iml

--- a/infinitest.filters
+++ b/infinitest.filters
@@ -1,0 +1,1 @@
+org\.jseats\.jbehave

--- a/src/main/java/org/jseats/SeatAllocatorLauncher.java
+++ b/src/main/java/org/jseats/SeatAllocatorLauncher.java
@@ -217,9 +217,9 @@ public class SeatAllocatorLauncher {
 		Result result = processor.process();
 
 		log.info("Result type: " + result.getType());
-		log.info("Number of seats: " + result.getNumerOfSeats());
+		log.info("Number of seats: " + result.getNumberOfSeats());
 
-		for (int i = 0; i < result.getNumerOfSeats(); i++) {
+		for (int i = 0; i < result.getNumberOfSeats(); i++) {
 			log.info("Seat " + i + "\t" + result.getSeatAt(i).getName() + "\t"
 					+ result.getSeatAt(i).getVotes());
 		}

--- a/src/main/java/org/jseats/model/ImmutableTally.java
+++ b/src/main/java/org/jseats/model/ImmutableTally.java
@@ -1,10 +1,9 @@
 package org.jseats.model;
 
+import javax.xml.bind.JAXBException;
 import java.io.OutputStream;
 
-import javax.xml.bind.JAXBException;
-
-public interface InmutableTally {
+public interface ImmutableTally {
 
 	public void toXML(OutputStream out) throws JAXBException;
 

--- a/src/main/java/org/jseats/model/Result.java
+++ b/src/main/java/org/jseats/model/Result.java
@@ -67,11 +67,11 @@ public class Result {
 		this.type = type;
 	}
 
-	public int getNumerOfSeats() {
+	public int getNumberOfSeats() {
 		return seats.size();
 	}
 
-	public int getNumerOfSeatsForCandidate(String candidate) {
+	public int getNumberOfSeatsForCandidate(String candidate) {
 
 		int count = 0;
 		for (Candidate innerCandidate : seats) {

--- a/src/main/java/org/jseats/model/Result.java
+++ b/src/main/java/org/jseats/model/Result.java
@@ -70,15 +70,14 @@ public class Result {
 	public int getNumerOfSeats() {
 		return seats.size();
 	}
-	
+
 	public int getNumerOfSeatsForCandidate(String candidate) {
 
 		int count = 0;
-		for(Candidate innerCandidate : seats)
-		{
-			if(innerCandidate.getName().contentEquals(candidate))
+		for (Candidate innerCandidate : seats) {
+			if (innerCandidate.getName().contentEquals(candidate))
 				count++;
-				
+
 		}
 		return count;
 	}
@@ -117,6 +116,15 @@ public class Result {
 		}
 
 		return false;
+	}
+
+	public void clear() {
+		type = null;
+		seats.clear();
+	}
+
+	public void empty() {
+		seats.clear();
 	}
 
 	@Override

--- a/src/main/java/org/jseats/model/Result.java
+++ b/src/main/java/org/jseats/model/Result.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Result {
 
-	public enum ResultType {
+	public static enum ResultType {
 
 		SINGLE("single-result"), MULTIPLE("multiple-result"), TIE("tie"), UNDECIDED(
 				"undecided");
@@ -120,7 +120,7 @@ public class Result {
 
 	public void clear() {
 		type = null;
-		seats.clear();
+		empty();
 	}
 
 	public void empty() {

--- a/src/main/java/org/jseats/model/SeatAllocationMethod.java
+++ b/src/main/java/org/jseats/model/SeatAllocationMethod.java
@@ -6,7 +6,7 @@ import org.jseats.model.tie.TieBreaker;
 
 public interface SeatAllocationMethod {
 
-	public abstract Result process(InmutableTally tally,
+	public abstract Result process(ImmutableTally tally,
 			Properties properties, TieBreaker tieBreaker)
 			throws SeatAllocationException;
 }

--- a/src/main/java/org/jseats/model/Tally.java
+++ b/src/main/java/org/jseats/model/Tally.java
@@ -17,7 +17,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "tally")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class Tally implements InmutableTally {
+public class Tally implements ImmutableTally {
 
 	static JAXBContext jc;
 	static Marshaller marshaller;

--- a/src/main/java/org/jseats/model/methods/AbsoluteMajorityMethod.java
+++ b/src/main/java/org/jseats/model/methods/AbsoluteMajorityMethod.java
@@ -4,7 +4,7 @@ import java.util.Properties;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.SeatAllocationException;
 import org.jseats.model.tie.TieBreaker;
@@ -13,7 +13,7 @@ import org.jseats.model.tie.TieBreaker;
 public class AbsoluteMajorityMethod extends QualifiedMajorityMethod {
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties, TieBreaker tieBreaker)
+	public Result process(ImmutableTally tally, Properties properties, TieBreaker tieBreaker)
 			throws SeatAllocationException {
 
 		// TODO this requires more testing for rounding errors.

--- a/src/main/java/org/jseats/model/methods/EqualProportionsMethod.java
+++ b/src/main/java/org/jseats/model/methods/EqualProportionsMethod.java
@@ -6,7 +6,7 @@ import java.text.NumberFormat;
 import java.util.Properties;
 
 import org.jseats.model.Candidate;
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.Result.ResultType;
 import org.jseats.model.SeatAllocationException;
@@ -33,7 +33,7 @@ public class EqualProportionsMethod implements SeatAllocationMethod {
 	}
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties,
+	public Result process(ImmutableTally tally, Properties properties,
 			TieBreaker tieBreaker) throws SeatAllocationException {
 
 		// Get properties

--- a/src/main/java/org/jseats/model/methods/HighestAveragesMethod.java
+++ b/src/main/java/org/jseats/model/methods/HighestAveragesMethod.java
@@ -3,7 +3,7 @@ package org.jseats.model.methods;
 import java.util.Properties;
 
 import org.jseats.model.Candidate;
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.Result.ResultType;
 import org.jseats.model.SeatAllocationException;
@@ -19,7 +19,7 @@ public abstract class HighestAveragesMethod implements SeatAllocationMethod {
 	public abstract double nextDivisor(int round);
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties,
+	public Result process(ImmutableTally tally, Properties properties,
 			TieBreaker tieBreaker) throws SeatAllocationException {
 
 		int numberOfCandidates = tally.getNumberOfCandidates();

--- a/src/main/java/org/jseats/model/methods/LargestRemainderMethod.java
+++ b/src/main/java/org/jseats/model/methods/LargestRemainderMethod.java
@@ -3,7 +3,7 @@ package org.jseats.model.methods;
 import java.util.Properties;
 
 import org.jseats.model.Candidate;
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.Result.ResultType;
 import org.jseats.model.SeatAllocationException;
@@ -19,7 +19,7 @@ public abstract class LargestRemainderMethod implements SeatAllocationMethod {
 	public abstract double quotient(int numberOfVotes, int numberOfSeats);
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties,
+	public Result process(ImmutableTally tally, Properties properties,
 			TieBreaker tieBreaker) throws SeatAllocationException {
 
 		int numberOfCandidates = tally.getNumberOfCandidates();

--- a/src/main/java/org/jseats/model/methods/QualifiedMajorityMethod.java
+++ b/src/main/java/org/jseats/model/methods/QualifiedMajorityMethod.java
@@ -2,7 +2,7 @@ package org.jseats.model.methods;
 
 import java.util.Properties;
 
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.SeatAllocationException;
 import org.jseats.model.Result.ResultType;
@@ -18,7 +18,7 @@ public class QualifiedMajorityMethod extends SimpleMajorityMethod {
 	private double qualifiedProportion;
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties, TieBreaker tieBreaker)
+	public Result process(ImmutableTally tally, Properties properties, TieBreaker tieBreaker)
 			throws SeatAllocationException {
 
 		if (properties.containsKey("minimumVotes")) {

--- a/src/main/java/org/jseats/model/methods/RankMethod.java
+++ b/src/main/java/org/jseats/model/methods/RankMethod.java
@@ -3,7 +3,7 @@ package org.jseats.model.methods;
 import java.util.Properties;
 
 import org.jseats.model.Candidate;
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.Result.ResultType;
 import org.jseats.model.SeatAllocationException;
@@ -17,7 +17,7 @@ public abstract class RankMethod implements SeatAllocationMethod {
 	static Logger log = LoggerFactory.getLogger(RankMethod.class);
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties,
+	public Result process(ImmutableTally tally, Properties properties,
 			TieBreaker tieBreaker) throws SeatAllocationException {
 
 		int numberOfCandidates = tally.getNumberOfCandidates();

--- a/src/main/java/org/jseats/model/methods/RankMethod.java
+++ b/src/main/java/org/jseats/model/methods/RankMethod.java
@@ -2,7 +2,6 @@ package org.jseats.model.methods;
 
 import java.util.Properties;
 
-import org.jseats.model.Candidate;
 import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.Result.ResultType;
@@ -36,54 +35,60 @@ public abstract class RankMethod implements SeatAllocationMethod {
 					+ candidatePriority[i]);
 		}
 
-		Result result = new Result(ResultType.MULTIPLE);
+		Result result;
+		if (numberOfSeats == 1)
+			result = new Result(ResultType.SINGLE);
+		else
+			result = new Result(ResultType.MULTIPLE);
+		Result tieResult = new Result(ResultType.TIE);
 
 		// Order by priority.
 		while (numberOfSeats > 0) {
 
 			int maxCandidate = -1;
 			int maxPriority = -1;
+			boolean isMaxCandidateATie = false;
 
+			// find max candidate
 			for (int candidate = 0; candidate < numberOfCandidates; candidate++) {
 
-				if (candidatePriority[candidate] == maxPriority) {
+				if (candidatePriority[candidate] > maxPriority) {
 
-					log.debug("Tie between  "
-							+ tally.getCandidateAt(maxCandidate) + " and "
-							+ tally.getCandidateAt(candidate));
+					isMaxCandidateATie = false;
+					tieResult.empty();
 
-					if (tieBreaker != null) {
-
-						log.debug("Using tie breaker: " + tieBreaker.getName());
-
-						Candidate topCandidate = tieBreaker.breakTie(
-								tally.getCandidateAt(candidate),
-								tally.getCandidateAt(maxCandidate));
-
-						if (topCandidate == null) {
-							Result tieResult = new Result(ResultType.TIE);
-							tieResult.addSeat(tally
-									.getCandidateAt(maxCandidate));
-							tieResult.addSeat(tally.getCandidateAt(candidate));
-
-							return tieResult;
-						} else {
-							maxCandidate = tally
-									.getCandidateIndex(topCandidate);
-							maxPriority = candidatePriority[maxCandidate];
-						}
-
-					} else {
-						Result tieResult = new Result(ResultType.TIE);
-						tieResult.addSeat(tally.getCandidateAt(maxCandidate));
-						tieResult.addSeat(tally.getCandidateAt(candidate));
-
-						return tieResult;
-					}
-				} else if (candidatePriority[candidate] > maxPriority) {
 					maxCandidate = candidate;
 					maxPriority = candidatePriority[candidate];
+
+				} else if (candidatePriority[candidate] == maxPriority) {
+					isMaxCandidateATie = true;
+					if (!tieResult.containsSeatForCandidate(tally
+							.getCandidateAt(maxCandidate)))
+						tieResult.addSeat(tally.getCandidateAt(maxCandidate));
+					tieResult.addSeat(tally.getCandidateAt(candidate));
 				}
+			}
+
+			// if there is a tie on max candidate, try to solve it with tie
+			// breaker.
+			if (isMaxCandidateATie) {
+
+				log.debug("Tie between  " + tieResult.toString());
+
+				if (tieBreaker == null)
+					return tieResult;
+
+				log.debug("Using tie breaker: " + tieBreaker.getName());
+
+				Result solvedTie = tieBreaker.breakTie(tieResult);
+
+				log.debug("solvedTie = " + solvedTie.toString());
+
+				if (solvedTie.getType() == ResultType.TIE)
+					return /* non- */solvedTie;
+				else
+					maxCandidate = tally.getCandidateIndex(solvedTie
+							.getSeatAt(0));
 			}
 
 			log.debug("Adding candidate " + tally.getCandidateAt(maxCandidate)

--- a/src/main/java/org/jseats/model/methods/SimpleMajorityMethod.java
+++ b/src/main/java/org/jseats/model/methods/SimpleMajorityMethod.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jseats.model.Candidate;
-import org.jseats.model.InmutableTally;
+import org.jseats.model.ImmutableTally;
 import org.jseats.model.Result;
 import org.jseats.model.Result.ResultType;
 import org.jseats.model.SeatAllocationException;
@@ -19,7 +19,7 @@ public class SimpleMajorityMethod implements SeatAllocationMethod {
 	static Logger log = LoggerFactory.getLogger(SimpleMajorityMethod.class);
 
 	@Override
-	public Result process(InmutableTally tally, Properties properties,
+	public Result process(ImmutableTally tally, Properties properties,
 			TieBreaker tieBreaker) throws SeatAllocationException {
 
 		List<Candidate> candidates = new ArrayList<Candidate>();

--- a/src/main/java/org/jseats/model/tie/BaseTieBreaker.java
+++ b/src/main/java/org/jseats/model/tie/BaseTieBreaker.java
@@ -11,13 +11,11 @@ import org.jseats.model.Result.ResultType;
 public abstract class BaseTieBreaker implements TieBreaker {
 
 	@Override
-	@Deprecated
 	public Candidate breakTie(List<Candidate> candidates) {
 		return innerBreakTie(new ArrayList<Candidate>(candidates));
 	}
 
 	@Override
-	@Deprecated
 	public Candidate breakTie(Candidate... candidates) {
 
 		List<Candidate> innerCandidates = new ArrayList<Candidate>(

--- a/src/main/java/org/jseats/model/tie/BaseTieBreaker.java
+++ b/src/main/java/org/jseats/model/tie/BaseTieBreaker.java
@@ -4,24 +4,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jseats.model.Candidate;
+import org.jseats.model.Result;
+import org.jseats.model.SeatAllocationException;
+import org.jseats.model.Result.ResultType;
 
 public abstract class BaseTieBreaker implements TieBreaker {
 
 	@Override
+	@Deprecated
 	public Candidate breakTie(List<Candidate> candidates) {
 		return innerBreakTie(new ArrayList<Candidate>(candidates));
 	}
-	
+
 	@Override
+	@Deprecated
 	public Candidate breakTie(Candidate... candidates) {
-		
+
 		List<Candidate> innerCandidates = new ArrayList<Candidate>(
 				candidates.length);
-		
+
 		for (Candidate candidate : candidates)
 			innerCandidates.add(candidate);
 
 		return innerBreakTie(innerCandidates);
+	}
+
+	@Override
+	public Result breakTie(Result tieResult) throws SeatAllocationException {
+
+		Candidate winnerCandidate = innerBreakTie(new ArrayList<Candidate>(
+				tieResult.getSeats()));
+		if (winnerCandidate == null) {
+			return tieResult;
+		} else {
+			Result result = new Result(ResultType.SINGLE);
+			result.addSeat(winnerCandidate);
+			return result;
+		}
 	}
 
 	public abstract Candidate innerBreakTie(List<Candidate> candidates);

--- a/src/main/java/org/jseats/model/tie/RandomTieBreaker.java
+++ b/src/main/java/org/jseats/model/tie/RandomTieBreaker.java
@@ -18,5 +18,4 @@ public class RandomTieBreaker extends BaseTieBreaker {
 	public Candidate innerBreakTie(List<Candidate> candidates) {
 		return candidates.get(rand.nextInt(candidates.size()));
 	}
-
 }

--- a/src/main/java/org/jseats/model/tie/TieBreaker.java
+++ b/src/main/java/org/jseats/model/tie/TieBreaker.java
@@ -29,6 +29,7 @@ public interface TieBreaker {
 	 * @return The top candidate where with more priority according to tie
 	 *         breaker implementation criteria. If unsolvable, null is returned.
 	 */
+	@Deprecated
 	public Candidate breakTie(List<Candidate> candidates);
 
 	/**
@@ -39,6 +40,7 @@ public interface TieBreaker {
 	 * @return The top candidate where with more priority according to tie
 	 *         breaker implementation criteria. If unsolvable, null is returned.
 	 */
+	@Deprecated
 	public Candidate breakTie(Candidate... candidate);
 
 	/**

--- a/src/main/java/org/jseats/model/tie/TieBreaker.java
+++ b/src/main/java/org/jseats/model/tie/TieBreaker.java
@@ -3,6 +3,8 @@ package org.jseats.model.tie;
 import java.util.List;
 
 import org.jseats.model.Candidate;
+import org.jseats.model.Result;
+import org.jseats.model.SeatAllocationException;
 
 /**
  * A TieBreaker will take a list of candidates and order them by a criteria
@@ -28,7 +30,7 @@ public interface TieBreaker {
 	 *         breaker implementation criteria. If unsolvable, null is returned.
 	 */
 	public Candidate breakTie(List<Candidate> candidates);
-	
+
 	/**
 	 * Same as breakTie(List<Candidate> candidates) but using varargs.
 	 * 
@@ -38,4 +40,15 @@ public interface TieBreaker {
 	 *         breaker implementation criteria. If unsolvable, null is returned.
 	 */
 	public Candidate breakTie(Candidate... candidate);
+
+	/**
+	 * This will take a TIE result, inspect the candidates and return a SINGLE
+	 * result with the TIE solved.
+	 * 
+	 * @param candidate
+	 *            A Result object containing only the candidates on a tie.
+	 *            ResultType of this Result object must be TIE.
+	 * @return A result of type SINGLE with only the winning candidate.
+	 */
+	public Result breakTie(Result tieResult) throws SeatAllocationException;
 }

--- a/src/test/java/org/jseats/jbehave/Steps.java
+++ b/src/test/java/org/jseats/jbehave/Steps.java
@@ -212,7 +212,7 @@ public class Steps {
 	@Then("result has $number seats")
 	@Alias("result has $number seat")
 	public void resultTypeIs(int number) {
-		assertEquals(number, result.getNumerOfSeats());
+		assertEquals(number, result.getNumberOfSeats());
 	}
 
 	@Then("result seat #$seat is $candidate")
@@ -237,7 +237,7 @@ public class Steps {
 	@Then("result has $number seats for $candidate")
 	@Alias("result has $number seat for $candidate")
 	public void resultNumberOfSeatsForCandidate(int number, String candidate) {
-		assertEquals(number, result.getNumerOfSeatsForCandidate(candidate));
+		assertEquals(number, result.getNumberOfSeatsForCandidate(candidate));
 	}
 
 	@Then("result seats do not contain $candidate")
@@ -251,7 +251,7 @@ public class Steps {
 	public void printResult() {
 
 		log.debug("type: " + result.getType());
-		log.debug("number of seats: " + result.getNumerOfSeats());
+		log.debug("number of seats: " + result.getNumberOfSeats());
 
 		for (int i = 0; i < result.getSeats().size(); i++) {
 			log.debug("seat #" + i + ": " + result.getSeatAt(i));

--- a/src/test/java/org/jseats/jbehave/Stories.java
+++ b/src/test/java/org/jseats/jbehave/Stories.java
@@ -2,6 +2,8 @@ package org.jseats.jbehave;
 
 import static org.jbehave.core.io.CodeLocations.codeLocationFromClass;
 
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.jbehave.core.configuration.Configuration;
@@ -21,6 +23,7 @@ import de.codecentric.jbehave.junit.monitoring.JUnitReportingRunner;
 public class Stories extends JUnitStories {
 
 	public Stories() {
+		configuredEmbedder().useMetaFilters(Arrays.asList("-skip"));
 		configuredEmbedder().embedderControls()
 				.doGenerateViewAfterStories(true)
 				.doIgnoreFailureInStories(false).doIgnoreFailureInView(false)

--- a/src/test/java/org/jseats/jbehave/Stories.java
+++ b/src/test/java/org/jseats/jbehave/Stories.java
@@ -3,7 +3,6 @@ package org.jseats.jbehave;
 import static org.jbehave.core.io.CodeLocations.codeLocationFromClass;
 
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.jbehave.core.configuration.Configuration;

--- a/src/test/java/org/jseats/unit/ExampleProcessorTest.java
+++ b/src/test/java/org/jseats/unit/ExampleProcessorTest.java
@@ -42,7 +42,7 @@ public class ExampleProcessorTest {
 		Result result = processor.process();
 
 		assertEquals(ResultType.SINGLE, result.getType());
-		assertEquals(1, result.getNumerOfSeats());
+		assertEquals(1, result.getNumberOfSeats());
 		assertEquals("White Party", result.getSeatAt(0).getName());
 		
 		// Let's try again
@@ -50,7 +50,7 @@ public class ExampleProcessorTest {
 		result = processor.process();
 		
 		assertEquals(ResultType.TIE, result.getType());
-		assertEquals(2, result.getNumerOfSeats());
+		assertEquals(2, result.getNumberOfSeats());
 		assertEquals("White Party", result.getSeatAt(0).getName());
 		assertEquals("Black Party", result.getSeatAt(1).getName());
 		
@@ -59,7 +59,7 @@ public class ExampleProcessorTest {
 		result = processor.process();
 
 		assertEquals(result.getType(),ResultType.UNDECIDED);
-		assertEquals(result.getNumerOfSeats(),0);
+		assertEquals(result.getNumberOfSeats(),0);
 		
 		// You can find more complex examples in /src/test/resources/stories
 	}

--- a/src/test/resources/stories/RankByVotes.Issue.8.story
+++ b/src/test/resources/stories/RankByVotes.Issue.8.story
@@ -1,0 +1,48 @@
+Sample story
+
+Narrative:
+In order to fix bug in https://github.com/pau-minoves/jseats/issues/8
+As a development team
+I want to fix RankMethod
+					 
+Scenario:  Base bug scenario
+Given empty scenario
+Given tally has candidate CandidateA with 100 votes
+Given tally has candidate CandidateB with 100 votes
+Given tally has candidate CandidateC with 75 votes
+Given tally has candidate CandidateD with 200 votes
+Given algorithm has property numberOfSeats set to 1
+Given algorithm has property groupSeatsPerCandidate set to true
+When process with RankByVotes method
+Then result type is TIE
+Then result has 2 seats
+Then result seat #0 is CandidateA
+Then result seat #1 is CandidateB
+!-- The tie is below the numberOfSeats threshold.  Result should be SINGLE -> CandidateD, as in the scenario below:
+					 
+Scenario:  Base bugfix scenario
+Given empty scenario
+Given tally has candidate CandidateA with 100 votes
+Given tally has candidate CandidateB with 100 votes
+Given tally has candidate CandidateC with 75 votes
+Given tally has candidate CandidateD with 200 votes
+Given algorithm has property numberOfSeats set to 1
+Given algorithm has property groupSeatsPerCandidate set to true
+When process with RankByVotes method
+Then result type is SINGLE
+Then result has 1 seats
+Then result seat #0 is CandidateD
+
+Scenario:  yet this must still be a tie
+Given empty scenario
+Given tally has candidate CandidateA with 200 votes
+Given tally has candidate CandidateB with 200 votes
+Given tally has candidate CandidateC with 75 votes
+Given tally has candidate CandidateD with 100 votes
+Given algorithm has property numberOfSeats set to 1
+Given algorithm has property groupSeatsPerCandidate set to true
+When process with RankByVotes method
+Then result type is TIE
+Then result has 2 seats
+Then result seat #0 is CandidateA
+Then result seat #1 is CandidateB

--- a/src/test/resources/stories/RankByVotes.Issue.8.story
+++ b/src/test/resources/stories/RankByVotes.Issue.8.story
@@ -1,11 +1,14 @@
 Sample story
 
 Narrative:
-In order to fix bug in https://github.com/pau-minoves/jseats/issues/8
+In order to fix bug when there are ties below the numberOfSeats threshold (See https://github.com/pau-minoves/jseats/issues/8)
 As a development team
-I want to fix RankMethod
-					 
+I want to fix RankMethod tie algorithm.
+
+
 Scenario:  Base bug scenario
+Meta: 
+@skip
 Given empty scenario
 Given tally has candidate CandidateA with 100 votes
 Given tally has candidate CandidateB with 100 votes
@@ -46,3 +49,70 @@ Then result type is TIE
 Then result has 2 seats
 Then result seat #0 is CandidateA
 Then result seat #1 is CandidateB
+
+Scenario:  and this must also be a tie
+Given empty scenario
+Given tally has candidate CandidateA with 200 votes and property minority=yes
+Given tally has candidate CandidateB with 200 votes
+Given tally has candidate CandidateC with 75 votes
+Given tally has candidate CandidateD with 300 votes
+Given algorithm has property numberOfSeats set to 2
+Given algorithm has property groupSeatsPerCandidate set to true
+When process with RankByVotes method
+Then result type is TIE
+Then result has 2 seats
+Then result seat #0 is CandidateA
+Then result seat #1 is CandidateB
+Given use tie breaker MinorityTieBreaker
+When process with RankByVotes method
+Then result type is MULTIPLE
+Then result has 2 seats
+Then result seat #0 is CandidateD
+Then result seat #1 is CandidateA
+
+Scenario:  full tie
+Given empty scenario
+Given tally has candidate CandidateA with 123 votes
+Given tally has candidate CandidateB with 123 votes
+Given tally has candidate CandidateC with 123 votes
+Given tally has candidate CandidateD with 123 votes
+Given algorithm has property numberOfSeats set to 1
+Given algorithm has property groupSeatsPerCandidate set to true
+When process with RankByVotes method
+Then result type is TIE
+Then result has 4 seats
+Then result seat #0 is CandidateA
+Then result seat #1 is CandidateB
+Then result seat #2 is CandidateC
+Then result seat #3 is CandidateD
+
+Scenario:  full tie with tieBreaker
+Given empty scenario
+Given tally has candidate CandidateA with 123 votes and property minority=yes
+Given tally has candidate CandidateB with 123 votes
+Given tally has candidate CandidateC with 123 votes
+Given tally has candidate CandidateD with 123 votes
+Given algorithm has property numberOfSeats set to 1
+Given algorithm has property groupSeatsPerCandidate set to true
+Given use tie breaker MinorityTieBreaker
+When process with RankByVotes method
+Then result type is SINGLE
+Then result has 1 seats
+Then result seat #0 is CandidateA
+
+Scenario:  full tie that tieBreaker can't break
+Given empty scenario
+Given tally has candidate CandidateA with 123 votes
+Given tally has candidate CandidateB with 123 votes
+Given tally has candidate CandidateC with 123 votes
+Given tally has candidate CandidateD with 123 votes
+Given algorithm has property numberOfSeats set to 1
+Given algorithm has property groupSeatsPerCandidate set to true
+Given use tie breaker MinorityTieBreaker
+When process with RankByVotes method
+Then result type is TIE
+Then result has 4 seats
+Then result seat #0 is CandidateA
+Then result seat #1 is CandidateB
+Then result seat #2 is CandidateC
+Then result seat #3 is CandidateD


### PR DESCRIPTION
This pull request fixes #8.

Changes:
- Cherry-pick some cleanups from @alvarogarcia7.
- Result can be cleaned (remove type and candidates) and emptied (remove candidates).
- BaseTieBreak now accepts and returns Result objects. This allows methods to easier track intermediate ties and save a loop.
- Added stories for #8 bug and corresponding bug fix.
